### PR TITLE
Practice issue: added a missing project dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
   "healpy",
   "numpy",
   "matplotlib",
-  "scipy"
+  "scipy",
+  "skycatalogs"
 ]
 
 [project.urls]


### PR DESCRIPTION
The **skycatalogs** package was missing.