### PR TITLE
Small flexibility changes

### DIFF
--- a/roman_imsim/skycat.py
+++ b/roman_imsim/skycat.py
@@ -251,6 +251,8 @@ class SkyCatalogLoader(InputLoader):
             "edge_pix": float,
             "obj_types": list,
             "mjd": float,
+            "xsize": int,
+            "ysize": int,
         }
         kwargs, safe = galsim.config.GetAllParams(config, base, req=req, opt=opt)
         wcs = galsim.config.BuildWCS(base["image"], "wcs", base, logger=logger)

--- a/roman_imsim/stamp.py
+++ b/roman_imsim/stamp.py
@@ -49,7 +49,10 @@ class Roman_stamp(StampBuilder):
         gal = galsim.config.BuildGSObject(base, "gal", logger=logger)[0]
         if gal is None:
             raise galsim.config.SkipThisObject("gal is None (invalid parameters)")
-        base["object_type"] = gal.object_type
+        if hasattr(gal, "object_type"):
+            base["object_type"] = gal.object_type
+        else:
+            base["object_type"] = ""
         bandpass = base["bandpass"]
         if not hasattr(gal, "flux"):
             # In this case, the object flux has not been precomputed


### PR DESCRIPTION
- **skycat**: add the two keywords `xsize` and `ysize` as optional keywords so they can be specified from the config file. If they are not in the config file, the code will behave as before.
- **stamp**: add a condition test before taking the `object_type` attribute. This allowed to use the code with objects not coming from SkyCatalog. At the moment `base["object_type"]` is not used so the line could be simply remove but I preserved in case we want to do something with it in the future.