### PR TITLE
Enable fft drawing

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -70,13 +70,14 @@ image:
     filter: { type: ObSeqData, field: filter }
     exptime: { type: ObSeqData, field: exptime }
 
+    draw_method: 'phot'
     # Photon shooting is way faster for chromatic objects than fft, especially when most of them
     # are fairly faint.  The cross-over point for achromatic objects is generally of order
     # flux=1.e6 or so (depending on the profile).  Most of our objects here are much fainter than
     # that.  The fft rendering for chromatic is a factor of 10 or so slower still, whereas
     # chromatic photon shooting is only slighly slower than achromatic, so the difference
     # is even more pronounced in this case.
-    draw_method: 'auto'
+    use_fft_bright: True
 
     # These are all by default turned on, but you can turn any of them off if desired:
     ignore_noise: True

--- a/config/tds.yaml
+++ b/config/tds.yaml
@@ -71,13 +71,14 @@ image:
     filter: { type: ObSeqData, field: filter }
     exptime: { type: ObSeqData, field: exptime }
 
+    draw_method: 'phot'
     # Photon shooting is way faster for chromatic objects than fft, especially when most of them
     # are fairly faint.  The cross-over point for achromatic objects is generally of order
     # flux=1.e6 or so (depending on the profile).  Most of our objects here are much fainter than
     # that.  The fft rendering for chromatic is a factor of 10 or so slower still, whereas
     # chromatic photon shooting is only slighly slower than achromatic, so the difference
     # is even more pronounced in this case.
-    draw_method: 'auto'
+    use_fft_bright: True
 
     # These are all by default turned on, but you can turn any of them off if desired:
     ignore_noise: True

--- a/config/was.yaml
+++ b/config/was.yaml
@@ -69,13 +69,14 @@ image:
     filter: { type: ObSeqData, field: filter }
     exptime: { type: ObSeqData, field: exptime }
 
+    draw_method: 'phot'
     # Photon shooting is way faster for chromatic objects than fft, especially when most of them
     # are fairly faint.  The cross-over point for achromatic objects is generally of order
     # flux=1.e6 or so (depending on the profile).  Most of our objects here are much fainter than
     # that.  The fft rendering for chromatic is a factor of 10 or so slower still, whereas
     # chromatic photon shooting is only slighly slower than achromatic, so the difference
     # is even more pronounced in this case.
-    draw_method: 'auto'
+    use_fft_bright: True
 
     # These are all by default turned on, but you can turn any of them off if desired:
     # ignore_noise: True

--- a/roman_imsim/sca.py
+++ b/roman_imsim/sca.py
@@ -52,6 +52,7 @@ class RomanSCAImageBuilder(ScatteredImageBuilder):
         req = {"SCA": int, "filter": str, "mjd": float, "exptime": float}
         opt = {
             "draw_method": str,
+            "use_fft_bright": bool,
             "stray_light": bool,
             "thermal_background": bool,
             "reciprocity_failure": bool,
@@ -82,7 +83,7 @@ class RomanSCAImageBuilder(ScatteredImageBuilder):
         self.sky_subtract = params.get("sky_subtract", False)
 
         # If draw_method isn't in image field, it may be in stamp.  Check.
-        self.draw_method = params.get("draw_method", base.get("stamp", {}).get("draw_method", "auto"))
+        self.draw_method = params.get("draw_method", base.get("stamp", {}).get("draw_method", "phot"))
 
         # pointing = CelestialCoord(ra=params['ra'], dec=params['dec'])
         # wcs = roman.getWCS(world_pos        = pointing,

--- a/roman_imsim/stamp.py
+++ b/roman_imsim/stamp.py
@@ -163,11 +163,9 @@ class Roman_stamp(StampBuilder):
         """
         method = galsim.config.ParseValue(config, "draw_method", base, str)[0]
         # Here we add the the custom "fft_poisson" method to the list of valid methods.
-        valid_methods = galsim.config.valid_draw_methods + ('fft_poisson',)
+        valid_methods = galsim.config.valid_draw_methods + ("fft_poisson",)
         if method not in valid_methods:
-            raise galsim.GalSimConfigValueError(
-                "Invalid draw_method.", method, valid_methods
-            )
+            raise galsim.GalSimConfigValueError("Invalid draw_method.", method, valid_methods)
         if method == "auto":
             if self.pupil_bin in [4, 2]:
                 logger.info("Auto -> Use FFT drawing for object %d.", base["obj_num"])

--- a/roman_imsim/stamp.py
+++ b/roman_imsim/stamp.py
@@ -46,6 +46,10 @@ class Roman_stamp(StampBuilder):
         """
         # print('stamp setup',process.memory_info().rss)
 
+        # Handle the "use_fft_bright" parameter as it can be provided in either image or stamp config
+        if "use_fft_bright" in base["image"] and "use_fft_bright" not in config:
+            config["use_fft_bright"] = base["image"]["use_fft_bright"]
+
         gal = galsim.config.BuildGSObject(base, "gal", logger=logger)[0]
         if gal is None:
             raise galsim.config.SkipThisObject("gal is None (invalid parameters)")
@@ -162,14 +166,19 @@ class Roman_stamp(StampBuilder):
         @returns method
         """
         method = galsim.config.ParseValue(config, "draw_method", base, str)[0]
-        # Here we add the the custom "fft_poisson" method to the list of valid methods.
-        valid_methods = galsim.config.valid_draw_methods + ("fft_poisson",)
-        if method not in valid_methods:
-            raise galsim.GalSimConfigValueError("Invalid draw_method.", method, valid_methods)
-        if method == "auto":
-            if self.pupil_bin in [4, 2]:
+        self.use_fft_bright = False
+        if "use_fft_bright" in config:
+            self.use_fft_bright = galsim.config.ParseValue(config, "use_fft_bright", base, bool)[0]
+
+        if method not in galsim.config.valid_draw_methods:
+            raise galsim.GalSimConfigValueError(
+                "Invalid draw_method.", method, galsim.config.valid_draw_methods
+            )
+
+        if method == "phot":
+            if self.pupil_bin in [4, 2] and self.use_fft_bright:
                 logger.info("Auto -> Use FFT drawing for object %d.", base["obj_num"])
-                return "fft_poisson"
+                return "fft"
             else:
                 logger.info("Auto -> Use photon shooting for object %d.", base["obj_num"])
                 return "phot"
@@ -274,51 +283,7 @@ class Roman_stamp(StampBuilder):
             maxN = galsim.config.ParseValue(config, "maxN", base, int)[0]
         # print('stamp draw2',process.memory_info().rss)
 
-        if method == "fft" or method == "fft_poisson":
-            fft_image = image.copy()
-            fft_offset = offset
-            kwargs = dict(
-                method="fft",
-                offset=fft_offset,
-                image=fft_image,
-            )
-            if not faint and config.get("fft_photon_ops"):
-                kwargs.update(
-                    {
-                        "photon_ops": galsim.config.BuildPhotonOps(config, "fft_photon_ops", base, logger),
-                        "maxN": maxN,
-                        "rng": self.rng,
-                        "n_subsample": 1,
-                    }
-                )
-
-            # Go back to a combined convolution for fft drawing.
-            gal = gal.withFlux(self.flux, bandpass)
-            prof = galsim.Convolve([gal] + psfs)
-            try:
-                prof.drawImage(bandpass, **kwargs)
-            except galsim.errors.GalSimFFTSizeError as e:
-                # I think this shouldn't happen with the updates I made to how the image size
-                # is calculated, even for extremely bright things.  So it should be ok to
-                # just report what happened, give some extra information to diagonose the problem
-                # and raise the error.
-                logger.error("Caught error trying to draw using FFT:")
-                logger.error("%s", e)
-                logger.error("You may need to add a gsparams field with maximum_fft_size to")
-                logger.error("either the psf or gal field to allow larger FFTs.")
-                logger.info("prof = %r", prof)
-                logger.info("fft_image = %s", fft_image)
-                logger.info("offset = %r", offset)
-                logger.info("wcs = %r", image.wcs)
-                raise
-            if method == "fft_poisson":
-                # Some pixels can end up negative from FFT numerics.  Just set them to 0.
-                fft_image.array[fft_image.array < 0] = 0.0
-                fft_image.addNoise(galsim.PoissonNoise(rng=self.rng))
-            # In case we had to make a bigger image, just copy the part we need.
-            image += fft_image[image.bounds]
-
-        else:
+        if method == "phot":
             # We already calculated realized_flux above.  Use that now and tell GalSim not
             # recalculate the Poisson realization of the flux.
             gal = gal.withFlux(self.realized_flux, bandpass)
@@ -353,9 +318,56 @@ class Roman_stamp(StampBuilder):
                 add_to_image=True,
                 poisson_flux=False,
             )
+        else:
+            fft_image = image.copy()
+            fft_offset = offset
+            kwargs = dict(
+                method=method,
+                offset=fft_offset,
+                image=fft_image,
+            )
+            if not faint and config.get("fft_photon_ops"):
+                kwargs.update(
+                    {
+                        "photon_ops": galsim.config.BuildPhotonOps(config, "fft_photon_ops", base, logger),
+                        "maxN": maxN,
+                        "rng": self.rng,
+                        "n_subsample": 1,
+                    }
+                )
+
+            # Go back to a combined convolution for fft drawing.
+            gal = gal.withFlux(self.flux, bandpass)
+            prof = galsim.Convolve([gal] + psfs)
+            try:
+                prof.drawImage(bandpass, **kwargs)
+            except galsim.errors.GalSimFFTSizeError as e:
+                # I think this shouldn't happen with the updates I made to how the image size
+                # is calculated, even for extremely bright things.  So it should be ok to
+                # just report what happened, give some extra information to diagonose the problem
+                # and raise the error.
+                logger.error("Caught error trying to draw using FFT:")
+                logger.error("%s", e)
+                logger.error("You may need to add a gsparams field with maximum_fft_size to")
+                logger.error("either the psf or gal field to allow larger FFTs.")
+                logger.info("prof = %r", prof)
+                logger.info("fft_image = %s", fft_image)
+                logger.info("offset = %r", offset)
+                logger.info("wcs = %r", image.wcs)
+                raise
+            # Check if we need to add photon noise for bright objects drawn
+            # with FFT because we switched from phot to fft above.
+            if self.use_fft_bright:
+                self.add_poisson_noise(fft_image)
+            # In case we had to make a bigger image, just copy the part we need.
+            image += fft_image[image.bounds]
         # print('stamp draw3',process.memory_info().rss)
 
         return image
+
+    def add_poisson_noise(self, fft_image):
+        fft_image.array[fft_image.array < 0] = 0.0
+        fft_image.addNoise(galsim.PoissonNoise(rng=self.rng))
 
 
 # Pick the right function to be _fix_seds.


### PR DESCRIPTION
In the current version of the code you can set the drawing method to `fft` but poisson noise will be generated and  added on top of the profile. This is mainly used for performance reason on some objects.  
Here I've created a new method called `fft_poisson` that replicate this behavior. Now if the user specify the method `fft` there will be no poisson noise added on top of the object. The method `auto` will automatically chose between `phot` and `fft_poisson`, same behavior as before. If desired, `fft_poisson` can also be specified from the config file directly.

**Validation**: This implementation has been tested against an images generated using the config from this [repo](https://github.com/DukeCosmology/SimHackJune2025) before modifications.