### PR TITLE
Fix a bug in the PSF initialization

### DIFF
--- a/roman_imsim/config/default.yaml
+++ b/roman_imsim/config/default.yaml
@@ -94,14 +94,10 @@ stamp:
         -
             type: ChargeDiff
 
-# psf:
-#     type: roman_psf
-#     # If omitted, it would figure this out automatically, because we are using the RomanSCA image
-#     # type.  But if we weren't, you'd have to tell it which SCA to build the PSF for.
-#     SCA: '@image.SCA'
-#     # n_waves defines how finely to sample the PSF profile over the bandpass.
-#     # Using 10 wavelengths usually gives decent accuracy.
-#     n_waves: 10
+psf:
+    type: RomanPSF
+    interpolator:
+        type: RomanPSFInterpolator
 
 # Define the galaxy type and positions to use
 gal:
@@ -113,8 +109,8 @@ input:
         # file_name: Roman_WAS_obseq_11_1_23.fits
         visit: 1
         SCA: '@image.SCA'
-    roman_psf:
-        SCA: '@image.SCA'
+    RomanPSFInterpolator:
+        kind: corners
         n_waves: 5
     sky_catalog:
         file_name: config/skyCatalog.yaml

--- a/roman_imsim/psf.py
+++ b/roman_imsim/psf.py
@@ -1,20 +1,68 @@
+"""
+Implementation of the RomanPSF builder
+
+RomanPSF is registered as a new GSObject that can be used within the `psf` section of the config file.
+It can be used in a few different ways depending if you want to draw the PSF at each locations from scratch or
+if you want to use interpolation to speed things up.
+
+Here is how the PSF Builder works:
+----------------------------------
+
+    RomanPSF
+        |
+        |------ No interpolation ---- Call the galsim.roman.getPSF function and parameters of this function
+        |                             can be set from the config file
+        |
+        |
+        |------ Interpolation ------- It requires the `interpolator` keyword in the config file and you need
+                    |                 to specify the type of interpolator, at the moment there is only
+                    |                 `RomanPSFInterpolator` available.
+                    |
+                    |------- Interpolator loader ---- To use an interpolator it needs to be initialized and
+                                    |                 for that we need to declare it in the `input` section of
+                                    |                 the config file as: `RomanPSFInterpolator`.
+                                    |
+                                    |----- Interpolation kind ---- For the `RomanPSFInterpolator` in the input
+                                                                   you need to specify which `kind` of
+                                                                   interpolation to use. At the moment only
+                                                                   `corners` is availalbe.
+
+Adding a new interpolation kind:
+--------------------------------
+
+You need to create it from the `PSFInterpolator` class and implement the `initPSF` and `getPSF` methods. Then
+you just need to register it to make GalSim aware of it by doing:
+```python
+RegisterPSFInterpolatorType("new_interpolator", NewPSFInterpolator)
+```
+And it will be automatically available from the config file by doing:
+```yaml
+input:
+  RomanPSFInterpolator:
+    kind: new_interpolator
+```
+"""
+
 import galsim
-import galsim.config
 import galsim.roman as roman
-from galsim.config import InputLoader, RegisterInputType
+from galsim.config import (
+    InputLoader,
+    RegisterInputType,
+    RegisterInputConnectedType,
+    RegisterValueType,
+    RegisterObjectType,
+)
+from galsim.errors import GalSimConfigValueError
+
+##########################
+# PSF Interpolator Input #
+##########################
+
+valid_psf_interpolator_types = {}
 
 
-class RomanPSF(object):
-    """Class building needed Roman PSFs."""
-
-    def __init__(
-        self,
-        n_waves=None,
-        extra_aberrations=None,
-    ):
-
-        self._n_waves = n_waves
-        self._extra_aberrations = extra_aberrations
+class PSFInterpolator:
+    """Base class for PSF interpolator"""
 
     def _parse_pupil_bin(self, pupil_bin):
         if pupil_bin == "achromatic":
@@ -68,6 +116,65 @@ class RomanPSF(object):
         image_ysize=None,
         logger=None,
     ):
+        raise NotImplementedError("initPSF must be implemented in subclasses")
+
+    def getPSF(self, pupil_bin, pos):
+        raise NotImplementedError("getPSF must be implemented in subclasses")
+
+
+class CornerPSFInterpolator(PSFInterpolator):
+    """Corner PSF interpolator
+
+    This class allows to builds the PSF in the corner of the image and center. Then instead of using the
+    "real" PSF variation of the PSF, it will be interpolated at the desired position. This saved a significant
+    amount of computation time.
+
+    Parameters
+    ----------
+    n_waves : int
+        Number of wavelengths to use for the Chromatic PSF interpolation in GalSim.
+    extra_aberrations : dict
+        Additional aberrations to apply to the PSF. (Not supported)
+    """
+
+    def __init__(
+        self,
+        n_waves=None,
+        extra_aberrations=None,
+    ):
+
+        self._n_waves = n_waves
+        self._extra_aberrations = extra_aberrations
+
+    def initPSF(
+        self,
+        SCA=None,
+        WCS=None,
+        bandpass=None,
+        image_xsize=None,
+        image_ysize=None,
+        logger=None,
+    ):
+        """Initialize the PSF interpolator.
+
+        This function sets up the PSF interpolator by building the PSF at the required positions for the
+        interpolation.
+
+        Parameters
+        ----------
+        SCA: int
+            SCA for which we build the interpolated PSF
+        WCS: galsim.WCS
+            WCS to use for the PSF
+        bandpass: galsim.Bandpass
+            Bandpass filter to use for the PSF
+        image_xsize: int
+            Size of the image in the x direction
+        image_ysize: int
+            Size of the image in the y direction
+        logger: logging.Logger
+            Logger
+        """
 
         logger = galsim.config.LoggerWrapper(logger)
 
@@ -111,7 +218,17 @@ class RomanPSF(object):
         """
         Return a PSF to be convolved with sources.
 
-        @param [in] what pupil binning to request.
+        Parameters
+        ----------
+        pupil_bin : int
+            Pupil binning to use for the PSF
+        pos : galsim.PositionD
+            Image position at which to evaluate the PSF
+
+        Return
+        ------
+        galsim.GSObject
+            The PSF to be convolved with sources.
         """
 
         # temporary
@@ -139,17 +256,36 @@ class RomanPSF(object):
         )
 
 
-class PSFLoader(InputLoader):
-    """PSF loader."""
+def RegisterPSFInterpolatorType(interp_type, builder, input_type=None):
+    """Register a PSF interpolator type for use by the config apparatus.
 
-    def __init__(self):
-        # Override some defaults in the base init.
-        super().__init__(init_func=RomanPSF, takes_logger=True, use_proxy=False)
+    Parameters
+    ----------
+        interp_type : str
+            The name of the type in the config dict.
+        builder: PSFInterpolator
+            A builder object to use for building the PSF interpolator.  It should
+            be an instance of a subclass of PSFInterpolator.
+        input_type: str or list of str
+            If the PSF interpolator utilises an input object, give the key name of the
+            input type here. (If it uses more than one, this may be a list.)
+    """
+    valid_psf_interpolator_types[interp_type] = builder
+    RegisterInputConnectedType(input_type, interp_type)
+
+
+RegisterPSFInterpolatorType("corners", CornerPSFInterpolator)
+
+
+class PSFInterpolatorLoader(InputLoader):
+    """PSF loader"""
 
     def getKwargs(self, config, base, logger):
         logger.debug("Get kwargs for PSF")
 
-        req = {}
+        req = {
+            "kind": str,
+        }
         opt = {
             "n_waves": int,
         }
@@ -164,7 +300,12 @@ class PSFLoader(InputLoader):
         return kwargs, safe
 
     def setupImage(self, input_obj, config, base, logger):
-        """ """
+        """
+        The PSF interpolator is initialized for each image.
+
+        NOTE: maybe look into how to bypass the initialization in case the new image has the same properties
+        as the existing one. (check on SCA, WCS, bandpass)
+        """
 
         bandpass = galsim.config.BuildBandpass(base["image"], "bandpass", base, logger)[0]
 
@@ -178,6 +319,130 @@ class PSFLoader(InputLoader):
         )
 
 
+def PSFInterpolatorLoaderHelper(kind, **kwargs):
+    """
+    Helper function to load a specific kind of PSF interpolator.
+
+    Parameters
+    ----------
+        kind : str
+            The kind of PSF interpolator to load.
+        **kwargs : dict
+            Additional keyword arguments to pass to the interpolator.
+
+    Returns
+    -------
+        PSFInterpolator
+            The loaded PSF interpolator.
+    """
+
+    if kind not in valid_psf_interpolator_types:
+        raise GalSimConfigValueError(
+            "Invalid interpolator.kind", kind, list(valid_psf_interpolator_types.keys())
+        )
+
+    return valid_psf_interpolator_types[kind](**kwargs)
+
+
 # Register this as a valid type
-RegisterInputType("roman_psf", PSFLoader())
-# RegisterObjectType('roman_psf', BuildRomanPSF, input_type='romanpsf_loader')
+# NOTE: If you add a new PSF interpolator, you do NOT need to change this. This is the "magic" of the helper
+#       function.
+RegisterInputType(
+    "RomanPSFInterpolator",
+    PSFInterpolatorLoader(
+        PSFInterpolatorLoaderHelper,
+        takes_logger=True,
+        use_proxy=False,
+    ),
+)
+
+
+##########################
+# PSF Interpolator Value #
+##########################
+
+
+def RomanPSFInterpolator(config, base, value_type):
+    """
+    Value type for the Roman PSF interpolator.
+
+    This allows to specify the type of PSF interpolator to use when building the Roman PSF. It will directly
+    return the initialized interpolator based on the `kind` of interpolator specified in the `input` section.
+    """
+
+    req = {
+        "type": str,
+    }
+
+    params, safe = galsim.config.GetAllParams(config, base, req=req)
+
+    interpolator = galsim.config.GetInputObj(params["type"], config, base, "RomanPSFInterpolator")
+
+    if not isinstance(interpolator, value_type):
+        raise TypeError(f"Invalid interpolator type. Got: {type(interpolator)} instead of {value_type}")
+
+    return interpolator, safe
+
+
+# NOTE: If you add a new PSF interpolator, you do NOT need to change this.
+RegisterValueType(
+    "RomanPSFInterpolator",
+    RomanPSFInterpolator,
+    [PSFInterpolator],
+    input_type=[
+        "PSFInterpolatorLoader",
+    ],
+)
+
+
+####################
+# Roman PSF Object #
+####################
+
+
+def BuildRomanPSF(config, base, ignore, gsparams, logger):
+    """
+    Roman PSF builder.
+
+    This function builds the Roman PSF and will use an interpolator if one is provided in the config.
+    """
+
+    req = {}
+    opt = {
+        "pupil_bin": int,
+        "n_waves": int,
+        "wavelength": float,
+        "interpolator": PSFInterpolator,
+    }
+    extra_ignore = [
+        "extra_aberrations",
+    ]
+
+    params, safe = galsim.config.GetAllParams(config, base, req=req, opt=opt, ignore=ignore + extra_ignore)
+
+    if "interpolator" in params:
+        builder = params["interpolator"]
+        psf = builder.getPSF(
+            base["pupil_bin"],
+            base["image_pos"],
+        )
+    else:
+        psf = roman.getPSF(
+            SCA=base["SCA"],
+            bandpass=base["bandpass"].name,
+            SCA_pos=base["image_pos"],
+            pupil_bin=params.get("pupil_bin", base.get("pupil_bin", 4)),
+            wcs=base["wcs"],
+            n_waves=params.get("n_waves", None),
+            extra_aberrations=None,
+            wavelength=params.get("wavelength", None),
+            gsparams=galsim.GSParams(**gsparams),
+            logger=logger,
+            high_accuracy=None,
+            approximate_struts=None,
+        )
+    safe = False
+    return psf, safe
+
+
+RegisterObjectType("RomanPSF", BuildRomanPSF)

--- a/roman_imsim/psf.py
+++ b/roman_imsim/psf.py
@@ -5,6 +5,19 @@ RomanPSF is registered as a new GSObject that can be used within the `psf` secti
 It can be used in a few different ways depending if you want to draw the PSF at each locations from scratch or
 if you want to use interpolation to speed things up.
 
+The config file would look something like this:
+```yaml
+psf:
+    type: RomanPSF
+    interpolator:
+        type: RomanPSFInterpolator
+
+input:
+    RomanPSFInterpolator:
+        kind: corners
+        n_waves: 5
+```
+
 Here is how the PSF Builder works:
 ----------------------------------
 
@@ -25,7 +38,7 @@ Here is how the PSF Builder works:
                                     |----- Interpolation kind ---- For the `RomanPSFInterpolator` in the input
                                                                    you need to specify which `kind` of
                                                                    interpolation to use. At the moment only
-                                                                   `corners` is availalbe.
+                                                                   `corners` is available.
 
 Adding a new interpolation kind:
 --------------------------------

--- a/roman_imsim/stamp.py
+++ b/roman_imsim/stamp.py
@@ -121,29 +121,6 @@ class Roman_stamp(StampBuilder):
 
         return image_size, image_size, image_pos, world_pos
 
-    def buildPSF(self, config, base, gsparams, logger):
-        """Build the PSF object.
-
-        For the Basic stamp type, this builds a PSF from the base['psf'] dict, if present,
-        else returns None.
-
-        Parameters:
-            config:     The configuration dict for the stamp field.
-            base:       The base configuration dict.
-            gsparams:   A dict of kwargs to use for a GSParams.  More may be added to this
-                        list by the galaxy object.
-            logger:     A logger object to log progress.
-
-        Returns:
-            the PSF
-        """
-        if base.get("psf", {}).get("type", "roman_psf") != "roman_psf":
-            return galsim.config.BuildGSObject(base, "psf", gsparams=gsparams, logger=logger)[0]
-
-        roman_psf = galsim.config.GetInputObj("roman_psf", config, base, "buildPSF")
-        psf = roman_psf.getPSF(self.pupil_bin, base["image_pos"])
-        return psf
-
     def getDrawMethod(self, config, base, logger):
         """Determine the draw method to use.
 


### PR DESCRIPTION
In the current implementation there is an assumption that only one image will be made per file. If one wants to simulate multiple SCAs and save them into a single file the PSF will only be initialized with the settings of the first image (SCA, WCS, bandpass). This is because the `__init__` of the class in the `InputLoader` is only called at the start of a new file in GalSim. This hasn't been a problem so far because the simulation was always run with one image per file. With this update we can now safely make multiple images of different SCA within a file and the PSF will be updated accordingly by doing the initialization in the `BuildImage` function using the method `setupImage` (see where this happen [here](https://github.com/GalSim-developers/GalSim/blob/4c04a1ea4aa4c652c25019c0c7b5881f7571035f/galsim/config/image.py#L279)).  
The update also include a small change regarding how the initialization is done. Now that we do it from the image builder we have access to some image characteristic which include its size. Instead of hard coding the image size to `roman.n_pix` for the corners, we now use the actual image size. This gives more flexibility to the code and allow to use images with a different sizes and have a more *"appropriate"* PSF interpolation.

Extra note: the `__init__` of `RomanPSF` could almost be removed but I prefer to keep it because I have in mind features that would require it.

**Validation**: This implementation has been tested against an images generated using the config from this [repo](https://github.com/DukeCosmology/SimHackJune2025) before modifications.