### PR TITLE
Updating setup.py > install_requires list -- related to issue #48

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
     author_email="michael.troxel@duke.edu",
     url="https://github.com/DukeCosmology/roman_imsim",
     packages=["roman_imsim"],
-    install_requires=["galsim", "fitsio", "astropy", "numpy", "skycatalogs", "packaging", "setuptools"],
+    install_requires=["galsim", "fitsio", "astropy", "numpy", "skycatalogs", "packaging"],
 )


### PR DESCRIPTION
For the consistency between pyproject.toml and setup.py, I updated the "install_requires" list in setup.py according to the list in pyproject.toml (even if it is not generally used in the current python practice).