### PR TITLE
Allow importing roman_imsim w/o ASDF

### DIFF
--- a/roman_imsim/__init__.py
+++ b/roman_imsim/__init__.py
@@ -20,7 +20,6 @@ from .detector_physics import *
 # Import core modules for public use
 from .noise import *
 from .obseq import *
-from .output_asdf import *
 from .photonOps import *
 from .psf import *
 from .sca import *

--- a/roman_imsim/config/asdf.yaml
+++ b/roman_imsim/config/asdf.yaml
@@ -1,6 +1,7 @@
 # Import just roman_imsim so we can access the registered template
 modules:
     - roman_imsim
+    - roman_imsim.output_asdf
 
 # Start with the default.yaml file, which we will modify below
 template: roman_imsim_default


### PR DESCRIPTION
While we list `roman_datamodels`, `gwcs` etc. in the requirements, we don't have this in the environment at DCC yet and we shouldn't impose them when we actually don't use them. This PR doesn't import `output_asdf` by default, thereby keeping these requirements optional. However, any new installation of `roman_imsim` will install their dependencies.