### PR TITLE
Add SCA field to bandpass configuration

### DIFF
--- a/roman_imsim/bandpass.py
+++ b/roman_imsim/bandpass.py
@@ -28,7 +28,6 @@ class RomanBandpassBuilder(BandpassBuilder):
 
         name = kwargs["name"]
         bandpass = models.bandpass.getBandpass(
-            red_limit=2000,
             bandname=name,
             sca=kwargs.get("SCA", None),
         )

--- a/roman_imsim/config/default.yaml
+++ b/roman_imsim/config/default.yaml
@@ -32,7 +32,7 @@ image:
         mjd: { type: ObSeqData, field: mjd }
 
     bandpass:
-        type: RomanBandpass
+        type: RomanBandpassTrimmed
         name: { type: ObSeqData, field: filter }
 
     # When you want to have multiple images generate the same random galaxies, then
@@ -134,7 +134,7 @@ input:
         file_name: config/skyCatalog.yaml
         edge_pix: 512
         mjd: { type: ObSeqData, field: mjd }
-        exptime: { type: ObSeqData, field: exptime }          
+        exptime: { type: ObSeqData, field: exptime }
         obj_types: ['diffsky_galaxy', 'snana', 'star', 'gaia_star']
 
 output:

--- a/roman_imsim/config/default.yaml
+++ b/roman_imsim/config/default.yaml
@@ -33,6 +33,7 @@ image:
 
     bandpass:
         type: RomanBandpassTrimmed
+        SCA: '@image.SCA'
         name: { type: ObSeqData, field: filter }
 
     # When you want to have multiple images generate the same random galaxies, then


### PR DESCRIPTION
This passes SCA as an explicit parameter to the bandpass constructed. This is expected to change the pixel images slightly.